### PR TITLE
Bumps pcomfortcloud to 0.0.16

### DIFF
--- a/custom_components/panasonic_ac/manifest.json
+++ b/custom_components/panasonic_ac/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "https://github.com/djbulsink/panasonic_ac/",
   "dependencies": [],
   "codeowners": ["Djbulsink", "SeraphimSerapis"],
-  "requirements": ["pcomfortcloud==0.0.14"]
+  "requirements": ["pcomfortcloud==0.0.16"]
 }


### PR DESCRIPTION
This fixes breaking changes in the Panasonic Comfort Cloud app api.